### PR TITLE
Allow passing startDir to moduleconfig to avoid using cached module.parent

### DIFF
--- a/lib/moduleConfig.js
+++ b/lib/moduleConfig.js
@@ -5,8 +5,13 @@ var cache = require("./cache"); //use requires caching to have a singleton
 var getConfigPath = require("./getConfigPath"); //use requires caching to have a singleton
 var path = require("path");
 
-module.exports = function moduleConfig(paths, loadPathFunction) {
-	var startDir = path.dirname(module.parent.parent.filename);
+module.exports = function moduleConfig(startDir, paths, loadPathFunction) {
+	if (Array.isArray(startDir)) {
+		// startDir was not passed in, so shift the arguments
+		loadPathFunction = paths;
+		paths = startDir;
+		startDir = path.dirname(module.parent.parent.filename);
+	}
 	var configPath;
 	var pathsId = paths.join(",");
 


### PR DESCRIPTION
This package doesn't work correctly together with Opentelemetry packages. 

In short, opentelemetry uses `require-in-the-middle` that has its own cache in addition to require cache which makes `module.parent` in [moduleConfig.js#L9](https://github.com/ebdrup/moduleconfig/blob/ba2d70b2676865a47a342b3120fe9cf2c642d402/lib/moduleConfig.js#L9) to always resolve to the same file.

This issue has been described in https://github.com/open-telemetry/opentelemetry-js/issues/3655. It has been fixed in `require-in-the-middle` [v7.0.0](https://github.com/elastic/require-in-the-middle/commit/ffb1808a6d04e71476395f18b339301aef61f731), but the additional cache has been reintroduced in [v7.1.1](https://github.com/elastic/require-in-the-middle/commit/5b5bf37266b7eb944e86be1d9a41012ab3c4f670#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R83-R85).